### PR TITLE
[Primary Reviewer: Joe] Rebuild 3.0.1 unitypackage with only the updated sdk and removing the old LeiaLoft folder

### DIFF
--- a/Unity/LeiaUnitySDK_3_0_1.zip
+++ b/Unity/LeiaUnitySDK_3_0_1.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b24621f90e54915e39928e4aea91357bcabb4325ad8b842a13aa4a5520a15d9e
-size 4290497
+oid sha256:b42764236d1e5e2063b4b2a5e1c651cb1134787a736b3bea08ab99940a88edc5
+size 4289211


### PR DESCRIPTION
The old zip file contained both the new sdk and the old LeiaLoft folder.
This update removes the old LeiaLoft folder so only the new SDK is included.
The SDK is built from the latest commit on the LeiaUnitySimpleSDK repo:
https://github.com/LeiaInc/LeiaUnitySimpleSDK/commit/2164c2a97817b8586a4befe5cbdc2d48f1ce1632

Here is the before and after when importing the package into unity:

BEFORE:
![image](https://github.com/LeiaInc/leiainc.github.io/assets/33501660/a940841a-4ceb-46f6-a604-1e857e3a3377)

AFTER:
![image](https://github.com/LeiaInc/leiainc.github.io/assets/33501660/9deaf067-a2be-4bf8-a843-a9e11c6a65f5)
